### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,8 +11,8 @@ colour==0.1.5
 ipython==7.7.0
 
 # only for conda
-gdal
-rasterio
+gdal==3.0.4
+rasterio==1.1.4
 
 # only for pip
 python_dateutil==2.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,8 +11,8 @@ colour==0.1.5
 ipython==7.7.0
 
 # only for conda
-gdal==2.4.1
-rasterio==1.0.24
+gdal
+rasterio
 
 # only for pip
 python_dateutil==2.8.0
@@ -26,7 +26,7 @@ rio-cogeo==1.1.0
 rio-tiler
 
 # common
-pyproj==1.9.6
+pyproj>=2.2.0
 affine==2.2.2
 setuptools==41.0.1
 cachetools==3.1.1

--- a/requirements_conda.txt
+++ b/requirements_conda.txt
@@ -1,2 +1,2 @@
-gdal==2.4.1
-rasterio==1.0.24
+gdal
+rasterio

--- a/requirements_conda.txt
+++ b/requirements_conda.txt
@@ -1,2 +1,2 @@
-gdal
-rasterio
+gdal==3.0.4
+rasterio==1.1.4


### PR DESCRIPTION
Some packages require an update to work

geopandas (0.7.0) requires rasterio >= 1.1
rio-tiller requires pyproj >=2.2.0

~This pull request removes version requirement for gdal and rasterio, so only their latest versions will be installed.~

Edit: I've specified the versions to avoid problems down the line. 
